### PR TITLE
logger.debug `xr.Variable` size before calling `np.asarray`

### DIFF
--- a/pangeo_forge_recipes/recipes/xarray_zarr.py
+++ b/pangeo_forge_recipes/recipes/xarray_zarr.py
@@ -8,7 +8,7 @@ import warnings
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass, field, replace
 from itertools import chain, product
-from math import ceil
+from math import ceil, floor
 from typing import Callable, Dict, Hashable, Iterator, List, Optional, Sequence, Set, Tuple
 
 import dask
@@ -596,11 +596,12 @@ def store_chunk(
                     f"Converting variable {vname} of {var.data.nbytes} bytes to `numpy.ndarray`"
                 )
                 if var.data.nbytes > 5*1e6:
+                    oversize_factor = round((var.data.nbytes/(5*1e6)/100), 2)
                     logger.warning(
-                        f"Variable {vname} of {var.data.nbytes} bytes is "
-                        f"{round((var.data.nbytes/(5*1e6)/100), 2)} times larger than recommended"
-                        " maximum variable array size of 500 MB. To improve performance, consider"
-                        " subsetting input using `XarrayZarrRecipe.subset_inputs` kwarg."
+                        f"Variable {vname} of {var.data.nbytes} bytes is {oversize_factor} times"
+                        " larger than recommended maximum variable array size of 500 MB. To improve"
+                        " performance, consider using `XarrayZarrRecipe.subset_inputs`; e.g., "
+                        f'`subset_inputs = {{"time": {floor(oversize_factor)}}}`.'
                     )
                 data = np.asarray(
                     var.data

--- a/pangeo_forge_recipes/recipes/xarray_zarr.py
+++ b/pangeo_forge_recipes/recipes/xarray_zarr.py
@@ -8,7 +8,7 @@ import warnings
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass, field, replace
 from itertools import chain, product
-from math import ceil, floor
+from math import ceil
 from typing import Callable, Dict, Hashable, Iterator, List, Optional, Sequence, Set, Tuple
 
 import dask
@@ -599,9 +599,12 @@ def store_chunk(
                     oversize_factor = round((var.data.nbytes/(5*1e6)/100), 2)
                     logger.warning(
                         f"Variable {vname} of {var.data.nbytes} bytes is {oversize_factor} times"
-                        " larger than recommended maximum variable array size of 500 MB. To improve"
-                        " performance, consider using `XarrayZarrRecipe.subset_inputs`; e.g., "
-                        f'`subset_inputs = {{"time": {floor(oversize_factor)}}}`.'
+                        " larger than recommended maximum variable array size of 500 MB. "
+                        ' Consider re-instantiating recipe with `subset_inputs = {"time": '
+                        f'{ceil(oversize_factor)}}}`. If "time" not in ds["{vname}"].dims, or '
+                        f'`len(ds["time"])` < {ceil(oversize_factor)}, substitute "time" for any '
+                        f'name in ds["{vname}"].dims with length >= {ceil(oversize_factor)}. '
+                        "`subset_inputs` also supports subsetting along multiple dimensions."
                     )
                 data = np.asarray(
                     var.data

--- a/pangeo_forge_recipes/recipes/xarray_zarr.py
+++ b/pangeo_forge_recipes/recipes/xarray_zarr.py
@@ -592,6 +592,11 @@ def store_chunk(
             var_coded.attrs = {}
             with dask.config.set(scheduler="single-threaded"):  # make sure we don't use a scheduler
                 var = xr.backends.zarr.encode_zarr_variable(var_coded)
+                logger.debug(
+                    f"Converting `xarray.Variable` of {var.data.nbytes} bytes to `numpy.ndarray`"
+                    "If execution crashes here, your input array may be too large for memory; "
+                    "consider using the `XarrayZarrRecipe.subset_inputs` kwarg to subset it."
+                )
                 data = np.asarray(
                     var.data
                 )  # TODO: can we buffer large data rather than loading it all?

--- a/pangeo_forge_recipes/recipes/xarray_zarr.py
+++ b/pangeo_forge_recipes/recipes/xarray_zarr.py
@@ -595,8 +595,8 @@ def store_chunk(
                 logger.debug(
                     f"Converting variable {vname} of {var.data.nbytes} bytes to `numpy.ndarray`"
                 )
-                if var.data.nbytes > 5*1e6:
-                    oversize_factor = round((var.data.nbytes/(5*1e6)/100), 2)
+                if var.data.nbytes > 500_000_000:
+                    oversize_factor = round((var.data.nbytes/(500_000_000)), 2)
                     logger.warning(
                         f"Variable {vname} of {var.data.nbytes} bytes is {oversize_factor} times"
                         " larger than recommended maximum variable array size of 500 MB. "

--- a/pangeo_forge_recipes/recipes/xarray_zarr.py
+++ b/pangeo_forge_recipes/recipes/xarray_zarr.py
@@ -600,7 +600,7 @@ def store_chunk(
                     logger.warning(
                         f"Variable {vname} of {var.data.nbytes} bytes is {oversize_factor} times"
                         " larger than recommended maximum variable array size of 500 MB. "
-                        ' Consider re-instantiating recipe with `subset_inputs = {"time": '
+                        ' Consider re-instantiating recipe with `subset_inputs = {"{concat_dim}": '
                         f'{ceil(oversize_factor)}}}`. If "time" not in ds["{vname}"].dims, or '
                         f'`len(ds["time"])` < {ceil(oversize_factor)}, substitute "time" for any '
                         f'name in ds["{vname}"].dims with length >= {ceil(oversize_factor)}. '

--- a/pangeo_forge_recipes/recipes/xarray_zarr.py
+++ b/pangeo_forge_recipes/recipes/xarray_zarr.py
@@ -593,10 +593,15 @@ def store_chunk(
             with dask.config.set(scheduler="single-threaded"):  # make sure we don't use a scheduler
                 var = xr.backends.zarr.encode_zarr_variable(var_coded)
                 logger.debug(
-                    f"Converting `xarray.Variable` of {var.data.nbytes} bytes to `numpy.ndarray`"
-                    "If execution crashes here, your input array may be too large for memory; "
-                    "consider using the `XarrayZarrRecipe.subset_inputs` kwarg to subset it."
+                    f"Converting variable {vname} of {var.data.nbytes} bytes to `numpy.ndarray`"
                 )
+                if var.data.nbytes > 5*1e6:
+                    logger.warning(
+                        f"Variable {vname} of {var.data.nbytes} bytes is "
+                        f"{round((var.data.nbytes/(5*1e6)/100), 2)} times larger than recommended"
+                        " maximum variable array size of 500 MB. To improve performance, consider"
+                        " subsetting input using `XarrayZarrRecipe.subset_inputs` kwarg."
+                    )
                 data = np.asarray(
                     var.data
                 )  # TODO: can we buffer large data rather than loading it all?

--- a/pangeo_forge_recipes/recipes/xarray_zarr.py
+++ b/pangeo_forge_recipes/recipes/xarray_zarr.py
@@ -605,9 +605,9 @@ def store_chunk(
                         f"Variable {vname} of {var.data.nbytes} bytes is {factor} times larger "
                         f"than specified maximum variable array size of {MAX_MEMORY} bytes. "
                         f'Consider re-instantiating recipe with `subset_inputs = {{"{concat_dim}": '
-                        f'{ceil(factor)}}}`. If `len(ds["{concat_dim}"])` < {ceil(factor)}`, '
-                        f'substitute "{vname}" for any name in ds["{vname}"].dims with length >= '
-                        f"{ceil(factor)} or consider subsetting along multiple dimensions."
+                        f'{ceil(factor)}}}`. If `len(ds["{concat_dim}"])` < {ceil(factor)}, '
+                        f'substitute "{concat_dim}" for any name in ds["{vname}"].dims with length '
+                        f">= {ceil(factor)} or consider subsetting along multiple dimensions."
                         " Setting PANGEO_FORGE_MAX_MEMORY env variable changes the variable array"
                         " size which will trigger this warning."
                     )


### PR DESCRIPTION
This additional debug aims to remind users of either/both of the following:

1. their variable arrays are too large for memory; or
2. that a `subset_inputs` option exists to deal with that circumstance

This avoids the possibility that a memory overload crash will occur silently, without making a suggestion to the user of how to resolve it.